### PR TITLE
Disable building at the same node

### DIFF
--- a/src/main/groovy/com/ofg/pipeline/core/link/AutoLink.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/link/AutoLink.groovy
@@ -49,7 +49,6 @@ public class AutoLink<P extends Project> extends AbstractPublishersFocusedJobCha
                         triggerWithNoParameters()
                         parameters {
                             currentBuild()
-                            sameNode()
                             if (predefinedProperties) {
                                 predefinedProps(predefinedProperties)
                             }

--- a/src/main/groovy/com/ofg/pipeline/core/link/ManualLink.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/link/ManualLink.groovy
@@ -21,7 +21,6 @@ public class ManualLink<P extends Project> extends AbstractPublishersFocusedJobC
                 buildPipelineTrigger(linkEndJobName) {
                     parameters {
                         currentBuild()
-                        sameNode()
                     }
                 }
             }


### PR DESCRIPTION
Subsequent builds should not share elements at the Jenkins level.
