### PR TITLE
Allow to define predefined properties in ManualLink

### DIFF
--- a/src/main/groovy/com/ofg/pipeline/core/link/AbstractPublishersFocusedJobChainLink.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/link/AbstractPublishersFocusedJobChainLink.groovy
@@ -2,7 +2,9 @@ package com.ofg.pipeline.core.link
 
 import com.ofg.pipeline.core.JobRef
 import com.ofg.pipeline.core.Project
+import com.ofg.pipeline.core.Variable
 import javaposse.jobdsl.dsl.Job
+import javaposse.jobdsl.dsl.helpers.common.DownstreamTriggerParameterContext
 
 import static com.google.common.base.Preconditions.checkNotNull
 
@@ -11,10 +13,16 @@ abstract class AbstractPublishersFocusedJobChainLink<P extends Project> implemen
     protected final static boolean ON_SAME_NODE_DISABLED = false
 
     private final JobRef<P> to
+
+    protected final Map<String, String> predefinedProperties
+    protected final String propertiesFileName
     protected final boolean onSameNode
 
-    protected AbstractPublishersFocusedJobChainLink(JobRef<P> to, boolean onSameNode) {
+    protected AbstractPublishersFocusedJobChainLink(JobRef<P> to, Map<String, String> predefinedProperties, String propertiesFileName,
+                                                    boolean onSameNode) {
         this.to = checkNotNull(to)
+        this.predefinedProperties = predefinedProperties
+        this.propertiesFileName = propertiesFileName
         this.onSameNode = onSameNode
     }
 
@@ -31,6 +39,43 @@ abstract class AbstractPublishersFocusedJobChainLink<P extends Project> implemen
             publishers configurer
         }
     }
+
+    AbstractPublishersFocusedJobChainLink<P> withPredefinedProperties(Variable... predefinedProperties) {
+        Map<String, String> propertiesMap = predefinedProperties.collectEntries { [it.name(), it.reference] }
+        return withPredefinedProperties(propertiesMap)
+    }
+
+    AbstractPublishersFocusedJobChainLink<P> withPredefinedProperties(Map<String, String> predefinedProperties) {
+        return createLink(end, predefinedProperties, propertiesFileName, onSameNode)
+    }
+
+    AbstractPublishersFocusedJobChainLink<P> withPropertiesFile(String propertiesFileName) {
+        return createLink(end, predefinedProperties, propertiesFileName, onSameNode)
+    }
+
+    AbstractPublishersFocusedJobChainLink<P> onSameNode(boolean onSameNode = true) {
+        return createLink(end, predefinedProperties, propertiesFileName, onSameNode)
+    }
+
+    protected Closure triggerParameters() {
+        return {
+            (delegate as DownstreamTriggerParameterContext).with {
+                currentBuild()
+                if (onSameNode) {
+                    sameNode()
+                }
+                if (predefinedProperties) {
+                    predefinedProps(predefinedProperties)
+                }
+                if (propertiesFileName) {
+                    propertiesFile(propertiesFileName)
+                }
+            }
+        }
+    }
+
+    abstract protected AbstractPublishersFocusedJobChainLink<P> createLink(JobRef<P> to, Map<String, String> predefinedProperties,
+                                                                           String propertiesFileName, boolean onSameNode);
 
     abstract protected Closure publisherClosureFor(String linkEndJobName)
 }

--- a/src/main/groovy/com/ofg/pipeline/core/link/ManualLink.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/link/ManualLink.groovy
@@ -7,15 +7,17 @@ import javaposse.jobdsl.dsl.helpers.publisher.PublisherContext
 class ManualLink<P extends Project> extends AbstractPublishersFocusedJobChainLink<P> {
 
     static <P extends Project> ManualLink<P> manual(JobRef<P> to) {
-        new ManualLink<P>(to, ON_SAME_NODE_DISABLED)
+        return new ManualLink<P>(to, [:], null, ON_SAME_NODE_DISABLED)
     }
 
-    private ManualLink(JobRef<P> to, boolean onSameNode) {
-        super(to, onSameNode)
+    private ManualLink(JobRef<P> to, Map<String, String> predefinedProperties, String propertiesFileName, boolean onSameNode) {
+        super(to, predefinedProperties, propertiesFileName, onSameNode)
     }
 
-    ManualLink<P> onSameNode(boolean onSameNode = true) {
-        return new ManualLink<P>(end, onSameNode)
+    @Override
+    protected AbstractPublishersFocusedJobChainLink<P> createLink(JobRef<P> to, Map<String, String> predefinedProperties, String propertiesFileName,
+                                                                  boolean onSameNode) {
+        return new ManualLink<>(to, predefinedProperties, propertiesFileName, onSameNode)
     }
 
     @Override
@@ -23,15 +25,9 @@ class ManualLink<P extends Project> extends AbstractPublishersFocusedJobChainLin
         return {
             (delegate as PublisherContext).with {
                 buildPipelineTrigger(linkEndJobName) {
-                    parameters {
-                        currentBuild()
-                        if (onSameNode) {
-                            sameNode()
-                        }
-                    }
+                    parameters triggerParameters()
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
The class hierarchy had to be refactored. Currently shared methods return `AbstractPublishersFocusedJobChainLink` which should be ok in most cases. Methods specific for a manual/auto link (currently there are none) could be still called directly after `auto()`/`manual()` method execution (or passed in the constructor if they are mandatory).
