### PR TITLE
Removed the assertion that blocked adding duplicated jobs.

### DIFF
--- a/src/main/groovy/com/ofg/pipeline/core/JobBuilder.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/JobBuilder.groovy
@@ -27,8 +27,6 @@ class JobBuilder<P extends Project> {
 
     void job(JobDefinition jobDefinition) {
         def jobType = jobDefinition.jobType
-        assert !jobs.containsKey(jobType),
-                "Attempted to define the same job twice. Type: [${jobType}], class: [${jobDefinition.class}]."
         jobs.put(jobType, jobDefinition)
     }
 


### PR DESCRIPTION
I am working at a usecase where we actually want to have two separate jobs that do exactly the same:
- automatic rollback on failing deploy to prod
- manual rollback possible after passing deploy to prod.

In both cases the DeployVersionToEnvironment objects will look alike, but they will be placed at two different pipeline steps.

If you think there is a better way to fix it than removing this suggestion, then please let me know.
