### PR TITLE
Improve generics support

### DIFF
--- a/src/main/groovy/com/ofg/pipeline/core/JobBuilder.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/JobBuilder.groovy
@@ -17,7 +17,7 @@ class JobBuilder<P extends Project> {
         this.jobFactory = new JobFactory(dslFactory)
     }
 
-    protected Map<JobType, JobDefinition> getJobs() {
+    protected Map<JobType, ? extends JobDefinition> getJobs() {
         return jobs
     }
 

--- a/src/main/groovy/com/ofg/pipeline/core/JobChain.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/JobChain.groovy
@@ -19,7 +19,7 @@ class JobChain<P extends Project> {
         this.start = start
     }
 
-    JobChain<P> then(Optional<JobRef<P>> optionalJob) {
+    JobChain<P> then(Optional<? extends JobRef<P>> optionalJob) {
         optionalJob.ifPresent({
             return then(optionalJob.get())
         } as Consumer<? super JobRef<P>>)
@@ -30,7 +30,7 @@ class JobChain<P extends Project> {
         return then(AutoLink.auto(job))
     }
 
-    JobChain<P> then(List<JobRef<P>> jobs) {
+    JobChain<P> then(List<? extends JobRef<P>> jobs) {
         jobs.each { then(it) }
         return this
     }
@@ -40,7 +40,7 @@ class JobChain<P extends Project> {
         return this
     }
 
-    void linkJobs(Map<JobType, Job> jobsByType, P project) {
+    void linkJobs(Map<JobType, ? extends Job> jobsByType, P project) {
         Job linkStartJob = getJob(jobsByType, start.jobType)
         links.each { JobChainLink<P> link ->
             link.configure(linkStartJob, project)
@@ -48,7 +48,7 @@ class JobChain<P extends Project> {
         }
     }
 
-    private Job getJob(Map<JobType, Job> jobsByType, JobType jobType) {
+    private Job getJob(Map<JobType, ? extends Job> jobsByType, JobType jobType) {
         Job linkStartJob = jobsByType[jobType]
         assert linkStartJob, "Attempted to configure links starting from job of type [$jobType], but no such job is defined"
         linkStartJob

--- a/src/main/groovy/com/ofg/pipeline/core/PipelineBuilder.groovy
+++ b/src/main/groovy/com/ofg/pipeline/core/PipelineBuilder.groovy
@@ -27,11 +27,11 @@ class PipelineBuilder<P extends Project> {
         stageContext.with(closure)
     }
 
-    //Cannot be private as an external closure is called in its context
+    //Cannot be private as an external closure is called in its context - #21
     class StageContext {
         private String stageName
 
-        void job(Optional<JobDefinition<? extends Job, P>> optionalJobDefinition) {
+        void job(Optional<? extends JobDefinition<? extends Job, P>> optionalJobDefinition) {
             optionalJobDefinition.ifPresent({
                 job(optionalJobDefinition.get())
             } as Consumer<? super JobDefinition<? extends Job, P>>)


### PR DESCRIPTION
To not fails with `@CompileStatic` when subtypes are used in the client code.