### PR TITLE
Simplified optional-manual job chaining.

### DIFF
--- a/jenkins-pipeline-core/src/main/groovy/com/ofg/pipeline/core/JobChain.groovy
+++ b/jenkins-pipeline-core/src/main/groovy/com/ofg/pipeline/core/JobChain.groovy
@@ -2,6 +2,7 @@ package com.ofg.pipeline.core
 
 import com.ofg.pipeline.core.link.AutoLink
 import com.ofg.pipeline.core.link.JobChainLink
+import com.ofg.pipeline.core.link.ManualLink
 import groovy.transform.CompileStatic
 import javaposse.jobdsl.dsl.Job
 
@@ -23,13 +24,24 @@ class JobChain<P extends Project> {
 
     JobChain<P> then(Optional<? extends JobRef<P>> optionalJob) {
         optionalJob.ifPresent({
-            return then(optionalJob.get())
+            then(optionalJob.get())
+        } as Consumer<? super JobRef<P>>)
+        return this
+    }
+
+    JobChain<P> thenManual(Optional<? extends JobRef<P>> optionalJob) {
+        optionalJob.ifPresent({
+            thenManual(optionalJob.get())
         } as Consumer<? super JobRef<P>>)
         return this
     }
 
     JobChain<P> then(JobRef<P> job) {
         return then(AutoLink.auto(job))
+    }
+
+    JobChain<P> thenManual(JobRef<P> job) {
+        return then(ManualLink.manual(job))
     }
 
     JobChain<P> then(List<? extends JobRef<P>> jobs) {


### PR DESCRIPTION
Why?
1) ManualLink.manual() does not accept optionals and even if it could, it would produce something link Optional<JobChainLink> - see point below
2) Due to type erasure there cannot be two methods accepting Optionals of different types.

Now, definition like this:
```
chain(of(jobs.DEPLOY_TO_STAGE)
   .then(manual(jobs.RUN_E2E_TESTS)))
})
```

can be made:
```
chain(of(jobs.DEPLOY_TO_STAGE)
   .thenManual(jobs.RUN_E2E_TESTS))
})
```

if jobs.RUN_E2E_TEST was Optional<> then some hacky way had to be used like:
```
def stageChain = of(jobs.DEPLOY_TO_STAGE)
jobs.RUN_E2E_TEST.ifPresent({stageChain.then(manual(it))})
chain(stageChain)
```

now it can be replaced with an example above